### PR TITLE
Bash script to be used on VPS

### DIFF
--- a/irccloud_cronjob
+++ b/irccloud_cronjob
@@ -1,4 +1,9 @@
 #!/bin/bash
+#### Instructions ###
+# chmod +x irccloud_cronjob
+# Add the following to your crontab
+# 0 * * * * $HOME/irccloud/irccloud_cronjob >/dev/null 2>&1
+
 export IRCCLOUD_USERNAME="your@email"
 export IRCCLOUD_PASSWORD="yourpassword"
 python3 "$HOME/irccloud.py"

--- a/irccloud_cronjob
+++ b/irccloud_cronjob
@@ -1,0 +1,4 @@
+#!/bin/bash
+export IRCCLOUD_USERNAME="your@email"
+export IRCCLOUD_PASSWORD="yourpassword"
+python3 "$HOME/irccloud.py"

--- a/irccloud_cronjob
+++ b/irccloud_cronjob
@@ -1,6 +1,7 @@
 #!/bin/bash
 #### Instructions ###
 # chmod +x irccloud_cronjob
+# Edit 'your@email' and 'yourpassword' to match your IRCCloud account
 # Add the following to your crontab
 # 0 * * * * $HOME/irccloud/irccloud_cronjob >/dev/null 2>&1
 


### PR DESCRIPTION
This simple `BASH` script helps to automate the process in VPS machines.

In order for this script to work you need to
`chmod +x irccloud_cronjob`

Just put the following inside a crontab:
`0 * * * * $HOME/irccloud/irccloud-cronjob >/dev/null 2>&1`

And that's it! This bash script will be called every hour to keep your connection alive